### PR TITLE
Fix E-ARK profile version

### DIFF
--- a/_metadata.liquid
+++ b/_metadata.liquid
@@ -6,7 +6,7 @@
 
 **Previous version:** [2.0]({{ site.baseurl }}{% link docs/diginstroom/sip/2.0/index.md %})
 
-**Compliant with E-ARK SIP:** [v2.2.1](https://earksip.dilcis.eu/)
+**Compliant with E-ARK SIP:** [v2.2.0](https://earksip.dilcis.eu/)
 
 **Published:** 
 

--- a/profiles/bibliographic.md
+++ b/profiles/bibliographic.md
@@ -660,7 +660,7 @@ root_directory
 <a id="example-representation-mets"></a>_Example 3: the structural map of a representation METS, with `@TYPE` and `@ORDER` attributes_
 
 ```xml
-<mets xmlns="http://www.loc.gov/METS/" xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" OBJID="representation_1" TYPE="Textual works - Print" PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP.xml" xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
+<mets xmlns="http://www.loc.gov/METS/" xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" OBJID="representation_1" TYPE="Textual works - Print" PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml" xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
     
     [...]
     

--- a/profiles/newspaper.md
+++ b/profiles/newspaper.md
@@ -390,7 +390,7 @@ root_directory
 <a id="example-representation-mets"></a>_Example 3: the structural map of a representation METS, with `@TYPE` and `@ORDER` attributes_
 
 ```xml
-<mets xmlns="http://www.loc.gov/METS/" xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" OBJID="representation_1" TYPE="Textual works - Print" PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP.xml" xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
+<mets xmlns="http://www.loc.gov/METS/" xmlns:csip="https://DILCIS.eu/XML/METS/CSIPExtensionMETS"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" OBJID="representation_1" TYPE="Textual works - Print" PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml" xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
     
     [...]
     

--- a/sip_structure/5_structure_package.md
+++ b/sip_structure/5_structure_package.md
@@ -117,7 +117,7 @@ The various requirements are listed in the table below.
       xmlns:xlink="http://www.w3.org/1999/xlink"
       OBJID="uuid-fae4ef8f-5954-4602-9a1e-0d6eb83f3727"
       TYPE="Photographs – Digital"
-      PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP.xml"
+      PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml"
       csip:CONTENTINFORMATIONTYPE="OTHER" csip:OTHERCONTENTINFORMATIONTYPE="https://data.hetarchief.be/id/sip/2.1/basic" 
       xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
 
@@ -186,7 +186,7 @@ The various requirements are listed in the table below.
 | Attribute | `mets/@PROFILE` |
 |-----------------------|-----------|
 | Name | METS profile |
-| Description | The URL of the E-ARK METS profile that the SIP conforms with.<br>This URL MUST be set to [`https://earksip.dilcis.eu/profile/E-ARK-SIP.xml`](https://earksip.dilcis.eu/profile/E-ARK-SIP.xml) to indicate conformance with the E-ARK specification. |
+| Description | The URL of the E-ARK METS profile that the SIP conforms with.<br>This URL MUST be set to [`https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml`](https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml) to indicate conformance with the E-ARK specification. |
 | Datatype | [URL]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#url) |
 | Cardinality | 1..1 |
 | Obligation | MUST |

--- a/sip_structure/6_structure_representation.md
+++ b/sip_structure/6_structure_representation.md
@@ -112,7 +112,7 @@ A summary of all possible references and their obligation is given in the table 
       xmlns:xlink="http://www.w3.org/1999/xlink"
       OBJID="representation_1"
       TYPE="Photographs – Digital"
-      PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP.xml" xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
+      PROFILE="https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml" xsi:schemaLocation="https://www.w3.org./1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd  http://www.loc.gov/METS/ https://www.loc.gov/standards/mets/mets.xsd https://DILCIS.eu/XML/METS/CSIPExtensionMETS https://earkcsip.dilcis.eu/schema/DILCISExtensionMETS.xsd ">
 
 <metsHdr>...</metsHdr>
 <dmdSec>...</dmdSec>
@@ -160,7 +160,7 @@ A summary of all possible references and their obligation is given in the table 
 | Attribute | `mets/@PROFILE` |
 |-----------------------|-----------|
 | Name | METS profile |
-| Description | The URL of the E-ARK METS profile that the SIP conforms with.<br>This URL MUST be set to [`https://earksip.dilcis.eu/profile/E-ARK-SIP.xml`](https://earksip.dilcis.eu/profile/E-ARK-SIP.xml) to indicate conformance with the E-ARK specification. |
+| Description | The URL of the E-ARK METS profile that the SIP conforms with.<br>This URL MUST be set to [`https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml`](https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml) to indicate conformance with the E-ARK specification. |
 | Datatype | [URL]({{ site.baseurl }}{% link docs/diginstroom/sip/2.1/2_terminology.md %}#url) |
 | Cardinality | 1..1 |
 | Obligation | MUST |


### PR DESCRIPTION
The meemoo SIP 2.1 files should be conformant with E-ARK version 2.2.0 meaning that `mets/@PROFILE` must have the value: "https://earksip.dilcis.eu/profile/E-ARK-SIP-v2-2-0.xml".